### PR TITLE
feat: add tag to token and add support for json-schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +312,7 @@ name = "recipe-parser"
 version = "0.5.0"
 dependencies = [
  "rstest",
+ "schemars",
  "serde",
  "serde_json",
  "winnow",
@@ -393,6 +400,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "schemars"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +447,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/recipe-parser/Cargo.toml
+++ b/crates/recipe-parser/Cargo.toml
@@ -12,6 +12,7 @@ homepage = { workspace = true }
 categories = ["command-line-interface", "parser-implementations"]
 
 [dependencies]
+schemars = { version = "0.8.16", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 winnow = "0.6.6"
 
@@ -23,4 +24,9 @@ serde_json = "1.0"
 path = "src/lib.rs"
 
 [features]
+
+# Adds serde Serialize implementation to Token
 serde = ["dep:serde"]
+
+# Add JsonSchema generation for Token
+schemars = ["dep:schemars"]


### PR DESCRIPTION
BREAKING CHANGE: The serialized output is no longer like
```
{"Ingredient": {"name": "foo", "amount": "1", "unit": "gr"}}
```
but instead
```
{"token": "Ingredient", "name": "foo", "amount": "1", "unit": "gr"}
```