### PR TITLE
fix: use serde content for token enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "recipe-parser"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "rstest",
  "schemars",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "recp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "Inflector",
  "clap",

--- a/crates/recipe-parser/src/parser.rs
+++ b/crates/recipe-parser/src/parser.rs
@@ -196,7 +196,7 @@ fn parse_backstory<'a>(input: &mut Input<'a>) -> PResult<&'a str> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 // if you use `zod` for example, using a tag makes it easy to use an undiscriminated union
-#[cfg_attr(feature = "serde", serde(tag = "token"))]
+#[cfg_attr(feature = "serde", serde(tag = "token", content = "content"))]
 pub enum Token<'a> {
     Metadata {
         key: &'a str,
@@ -582,8 +582,17 @@ mod test {
         let serialized = serde_json::to_string(&token).expect("failed to serialize");
         assert_eq!(
             serialized,
-            r#"{"token":"Ingredient","name":"quinoa","quantity":"200","unit":"gr"}"#
+            r#"{"token":"Ingredient","content":{"name":"quinoa","quantity":"200","unit":"gr"}}"#
         );
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_token_serialization_creates_right_payload_single_string() {
+        let token = Token::Word("holis");
+
+        let serialized = serde_json::to_string(&token).expect("failed to serialize");
+        assert_eq!(serialized, r#"{"token":"Word","content":"holis"}"#);
     }
 
     #[test]


### PR DESCRIPTION
BREAKING CHANGE:
json output is no longer like:
```json
{"token": "Ingredient", "name": "foo", "amount": "1", "unit": "gr"}
```
now:
```json
{"token": "Ingredient", "content": {"name": "foo", "amount": "1", "unit": "gr"}}
```
The problem is that serde was failing to serialize enum variants that contained a single string